### PR TITLE
Add support for self-signed ssl and bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 public/robots.txt
+__pycache__
 
 # OS generated files #
 ######################

--- a/reflect_client/Client.py
+++ b/reflect_client/Client.py
@@ -47,7 +47,9 @@ class Client:
 
     # Close socket connection when class instance removed
     def __del__(self):
-        self._socket.close()
+        # Close socket if connected
+        if (self._con == Connection.AF_UNIX):
+            self._socket.close()
 
     # Resolve connection type from endpoint string.
     # If the string is a valid URL we will treat it as HTTP otherwise we will assume it's a path on disk to a UNIX socket file.
@@ -75,9 +77,9 @@ class Client:
         # Remove leading "/" if present, as it's already present in self._endpoint
         endpoint = endpoint if endpoint[-1] != "/" else endpoint[:-1]
         
-        resp = requests.request(method.name, self._endpoint + endpoint, headers=self.http_headers(), data=json.dumps(payload))
-        # Return response as tuple of response code and response body as plain text
-        return (resp.status_code, resp.text)
+        resp = requests.request(method.name, self._endpoint + endpoint, verify=self._https_peer_verify, headers=self.http_headers(), data=json.dumps(payload))
+        # Return response as tuple of response code and response body as decoded JSON (mixed)
+        return (resp.status_code, json.loads(resp.text))
 
     def socket_txn(self, endpoint: str, method: Union[Method, str] = None, payload: list = None) -> tuple:
         data = f'["{endpoint}","{method.name}","{json.dumps(payload)}"]'


### PR DESCRIPTION
This PR adds support for self-signed certificates. Set the `https_self_signed` flag in .env.yml to allow self signed certs (defaults to False)

This PR also implements the following:
- Only attempt to close socket connection if Connection is AF_UNIX
- Return decoded JSON from `call()` instead of plaintext string